### PR TITLE
Added Typings

### DIFF
--- a/dragula.d.ts
+++ b/dragula.d.ts
@@ -1,0 +1,47 @@
+// Type definitions for dragula v2.1.2
+// Project: http://bevacqua.github.io/dragula/
+// Definitions by: Paul Welter <https://github.com/pwelter34>
+//                 Yang He <https://github.com/abruzzihraig>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare var dragula: dragula.Dragula;
+
+export = dragula;
+export as namespace dragula;
+
+declare namespace dragula {
+    interface DragulaOptions {
+        containers?: Element[];
+        isContainer?: (el?: Element) => boolean;
+        moves?: (el?: Element, container?: Element, handle?: Element, sibling?: Element) => boolean;
+        accepts?: (el?: Element, target?: Element, source?: Element, sibling?: Element) => boolean;
+        invalid?: (el?: Element, target?: Element) => boolean;
+        direction?: string;
+        copy?: ((el: Element, source: Element) => boolean) | boolean;
+        revertOnSpill?: boolean;
+        removeOnSpill?: boolean;
+        delay?: boolean | number;
+        mirrorContainer?: Element;
+        ignoreInputTextSelection?: boolean;
+    }
+
+    interface Drake {
+        containers: Element[];
+        dragging: boolean;
+        start(item:Element): void;
+        end(): void;
+        cancel(revert:boolean): void;
+        cancel(): void;
+        remove(): void;
+        on(events: string, callback: Function): void;
+        destroy(): void;
+    }
+
+    interface Dragula {
+        (containers: Element[], options: DragulaOptions): Drake;
+        (containers: Element, options: DragulaOptions): Drake;
+        (containers: Element[]): Drake;
+        (options: DragulaOptions): Drake;
+        (): Drake;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "npm run lint && browserify test/*.js | tape-run",
     "test-watch": "hihat test/*.js -p tap-dev-tool"
   },
+  "typings": "./dragula.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/bevacqua/dragula.git"


### PR DESCRIPTION
If Typescript is run in strict mode the following Error is thrown: 

> ERROR in node_modules/@swimlane/ngx-dnd/lib/services/drake-store.service.d.ts(1,35): error TS7016: Could not find a declaration file for module '@swimlane/dragula'. 'C:/Develop/Repos/phonebook/phonebook-ui/node_modules/@swimlane/dragula/dragula.js' implicitly has an 'any' type.
>   Try `npm install @types/@swimlane/dragula` if it exists or add a new declaration (.d.ts) file containing `declare module '@swimlane/dragula';`

As the typings are not existent for `@swimlane/dragula` (only for the dragula package) I have included them directly. 
This is the only package in my project still not typed, please consider merging it even if the dragula package should be the one providing it. 
Furthermore you are referencing the `@swimlane/dragula` module for the installation of `@swimlane/ngx-dnd` module. So every Angular developer, with enabled strict mode will have the same problem. 